### PR TITLE
feat: add --include-breaks option

### DIFF
--- a/myday.py
+++ b/myday.py
@@ -92,11 +92,15 @@ def ignore_entries(
     return entries
 
 
-def calculate_total_time(entries: List[List[str]]) -> tuple[int, int]:
-    """Calculate total time spent on activities, excluding breaks."""
+def calculate_total_time(
+    entries: List[List[str]], include_breaks: bool = False
+) -> tuple[int, int]:
+    """Calculate total time spent on activities, optionally including breaks."""
     total_minutes = 0
     for _, duration, activity in entries:
-        if duration != "-" and not activity.strip().startswith(BREAK_ACTIVITY_ID):
+        if duration != "-" and (
+            include_breaks or not activity.strip().startswith(BREAK_ACTIVITY_ID)
+        ):
             h, m = map(int, duration.split(":"))
             total_minutes += h * 60 + m
     total_hours = total_minutes // 60
@@ -133,7 +137,22 @@ def calculate_total_time(entries: List[List[str]]) -> tuple[int, int]:
     show_default=True,
     help="Base directory to search for files",
 )
-def main(filename, today, yesterday, filter_text, ignore_case, ignore_text, base_path):
+@click.option(
+    "--include-breaks",
+    is_flag=True,
+    default=False,
+    help='Include activities containing "Break" in total time calculation',
+)
+def main(
+    filename,
+    today,
+    yesterday,
+    filter_text,
+    ignore_case,
+    ignore_text,
+    base_path,
+    include_breaks,
+):
     """Summarize time entries from a markdown file.
     If no filename is provided, defaults to today's file.
     If --today or --yesterday is specified, uses the respective file.
@@ -177,7 +196,7 @@ def main(filename, today, yesterday, filter_text, ignore_case, ignore_text, base
                 entries, headers=["Time", "Duration", "Activity"], tablefmt="github"
             )
         )
-        total_hours, total_rem_minutes = calculate_total_time(entries)
+        total_hours, total_rem_minutes = calculate_total_time(entries, include_breaks)
         print(f"\nTotal time: {total_hours}:{total_rem_minutes:02d}")
     else:
         print("No activities match the filter.")

--- a/tests/test_myday.py
+++ b/tests/test_myday.py
@@ -152,3 +152,17 @@ Some notes here.
             ["09:00", "3:00", "Work"],
             ["13:00", "-", "End"],
         ]
+
+    def test_calculate_total_time_include_breaks(self):
+        entries = [
+            ["08:00", "1:00", "Email"],
+            ["09:00", "0:30", "Break"],
+            ["09:30", "2:00", "Work"],
+            ["11:30", "-", "End"],
+        ]
+        # With include_breaks=True, "Break" entry should be included in total
+        total_hours, total_rem_minutes = calculate_total_time(
+            entries, include_breaks=True
+        )
+        assert total_hours == 3
+        assert total_rem_minutes == 30


### PR DESCRIPTION
When specified, --include-breaks includes breaks in the time report. By default, breaks are ignored.

fix: #45