### PR TITLE
fix: fix duration calculation for blank activities

### DIFF
--- a/examples/2025-06-06.md
+++ b/examples/2025-06-06.md
@@ -8,5 +8,7 @@
 13:30 Email
 14:00 Task 3
 16:00 Task 4
+16:30
+17:00
 17:30 Wrap-up meeting
 18:00 End

--- a/myday.py
+++ b/myday.py
@@ -37,7 +37,7 @@ def parse_time_entries(time_lines: List[str]) -> List[List[str]]:
     activities = []
     wikilink_pattern = re.compile(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]")
     for line in time_lines:
-        match = re.match(r"^(\d{2}:\d{2})\s+(.*)", line)
+        match = re.match(r"^(\d{2}:\d{2})\s?(.*)", line)
         if match:
             times.append(match.group(1))
             # Remove markdown wikilinks from activity text

--- a/tests/test_myday.py
+++ b/tests/test_myday.py
@@ -61,13 +61,15 @@ Some notes here.
             "08:00 Breakfast",
             "09:00 Work",
             "12:00 Lunch",
+            "12:30",
             "13:00 End",
         ]
         result = parse_time_entries(time_lines)
         assert result == [
             ["08:00", "1:00", "Breakfast"],
             ["09:00", "3:00", "Work"],
-            ["12:00", "1:00", "Lunch"],
+            ["12:00", "0:30", "Lunch"],
+            ["12:30", "0:30", ""],
             ["13:00", "-", "End"],
         ]
 


### PR DESCRIPTION
If an activity has a blank name, treat it as a separate activity rather than including its time with the previous non-blank activity.

fix: #46