### PR TITLE
feat(myday): Exclude break time from project and type summaries

### DIFF
--- a/myday.py
+++ b/myday.py
@@ -239,14 +239,15 @@ def parse_time_entries(time_lines: List[str]) -> List[List[str]]:
 
 
 def summarize_by_project(entries: List[List[str]]) -> Dict[str, int]:
-    """Summarize total time by project."""
+    """Summarize total time by project, excluding breaks."""
     project_totals = defaultdict(int)
 
     for entry in entries:
         duration_str = entry[1]
+        type_name = entry[2]
         project = entry[3]
 
-        if duration_str != "-":
+        if duration_str != "-" and type_name != "Break":
             h, m = map(int, duration_str.split(":"))
             total_minutes = h * 60 + m
             project_totals[project] += total_minutes
@@ -255,14 +256,14 @@ def summarize_by_project(entries: List[List[str]]) -> Dict[str, int]:
 
 
 def summarize_by_type(entries: List[List[str]]) -> Dict[str, int]:
-    """Summarize total time by type."""
+    """Summarize total time by type, excluding breaks."""
     type_totals = defaultdict(int)
 
     for entry in entries:
         duration_str = entry[1]
         type_name = entry[2]
 
-        if duration_str != "-":
+        if duration_str != "-" and type_name != "Break":
             h, m = map(int, duration_str.split(":"))
             total_minutes = h * 60 + m
             type_totals[type_name] += total_minutes


### PR DESCRIPTION
## Summary
- Modified `summarize_by_project()` to exclude Break entries from project time calculations
- Modified `summarize_by_type()` to exclude Break entries from type time calculations
- Updated function docstrings to clarify that breaks are excluded from summaries

## Changes Made
- Break activities (type "B") no longer appear in "Summary by Project" tables
- Break activities no longer appear in "Summary by Type" tables
- The `summarize_by_focus()` function already handled breaks correctly
- All existing functionality remains intact

## Test Plan
- [x] All existing tests pass (54/54)
- [x] Manual verification confirms breaks are excluded from summaries
- [x] Code quality checks pass (ruff, black)
- [x] Pre-commit hooks pass

## Impact
This change improves the accuracy of work time summaries by excluding non-productive break time from project and type calculations, while still allowing breaks to be tracked and viewed in detailed time entries.

🤖 Generated with [Claude Code](https://claude.ai/code)